### PR TITLE
Reference C++/Kokkos/EKAT (CKE) implementations

### DIFF
--- a/nested_loops/Makefile
+++ b/nested_loops/Makefile
@@ -2,6 +2,17 @@ FC =
 FFLAGS =
 LDFLAGS =
 
+# if using C++/Kokkos, set
+# * the EKAT installation root dir
+# * CKE_PACK_SIZE
+EKAT = # no default
+CKE_PACK_SIZE = 4 # CPU default; want 1 on GPU for max performance, but 4 will work
+include make.inc
+CKE_FLAGS = -DUSE_CKE -DCKE_PACK_SIZE=${CKE_PACK_SIZE} \
+	-I${EKAT}/include -I${EKAT}/include/kokkos
+CKE_LIBS = -lstdc++ -L${EKAT}/lib -L${EKAT}/lib64 -lekat -lkokkoscore -ldl
+CKE_OBJECTS = cke_mod.o cke.o cke_impl1.o
+
 dummy:
 	@echo "ERROR: Unknown target"
 
@@ -50,8 +61,8 @@ ifort:
 
 gnu:
 	make nested \
-	"FC=gfortran" \
-	"FFLAGS=-O3 -m64" \
+	"FC=mpif90" \
+	"FFLAGS=-O3 -m64 -Wall -pedantic" \
 	"LDFLAGS=-O3 -m64"
 
 llvm:
@@ -60,11 +71,49 @@ llvm:
 	"FFLAGS=-O3" \
 	"LDFLAGS=-O3"
 
+gnu-cpu-cke:
+	make nestedcke \
+	"FC=mpif90" \
+	"CXX=mpicxx" \
+	"FFLAGS=-g -O3 -m64 -fopenmp -Wall -pedantic -DUSE_CKE" \
+	"CXXFLAGS=-std=c++14 -g -O3 -m64 -fopenmp -Wall -pedantic ${CKE_FLAGS}" \
+	"LDFLAGS=-O3 -m64 -fopenmp ${CKE_LIBS}"
+
+gnu-weaver-cke:
+	make nestedcke \
+	"FC=mpif90" \
+	"CXX=mpicxx" \
+	"FFLAGS=-g -O3 -m64 -fopenmp -Wall -pedantic -DUSE_CKE" \
+	"CXXFLAGS=-std=c++14 -g -O3 -m64 -fopenmp -Wall -pedantic \
+		-arch=sm_70 --expt-extended-lambda ${CKE_FLAGS}" \
+	"LDFLAGS=-O3 -m64 -fopenmp ${CKE_LIBS} -lcudadevrt -lcudart_static -lrt"
+
+gnu-summit-cke:
+	make nestedcke \
+	"FC=mpif90" \
+	"CXX=mpicxx" \
+	"FFLAGS=-g -O3 -m64 -fopenmp -Wall -pedantic -DUSE_CKE -DNO_MPI" \
+	"CXXFLAGS=-std=c++14 -g -O3 -m64 -fopenmp -Wall -pedantic \
+		-arch=sm_70 --expt-extended-lambda ${CKE_FLAGS}" \
+	"LDFLAGS=-O3 -m64 -fopenmp ${CKE_LIBS} -L${CUDAPATH}/lib64 -lcuda -lcudart"
+
+gnu-compy-cke:
+	make nestedcke \
+	"FC=mpiifort" \
+	"CXX=mpiicpc" \
+	"FFLAGS=-g -O3 -m64 -fopenmp -xcore-avx512 -DUSE_CKE -DNO_MPI" \
+	"CXXFLAGS=-std=c++14 -g -O3 -m64 -fopenmp -xcore-avx512 ${CKE_FLAGS}" \
+	"LDFLAGS=-O3 -m64 -fopenmp ${CKE_LIBS}"
+
 nested: nested.o timerMod.o
 	@echo "Linking"
 	$(FC) $(LDFLAGS) -o nested nested.o timerMod.o
 
-nested.o: nested.F90 timerMod.o
+nestedcke: nested.o timerMod.o $(CKE_OBJECTS)
+	@echo "Linking"
+	$(FC) -o nested nested.o timerMod.o $(CKE_OBJECTS) $(LDFLAGS)
+
+nested.o: nested.F90 timerMod.o cke_mod.o
 	@echo "Building nested source"
 	$(FC) -c $(FFLAGS) nested.F90
 
@@ -72,6 +121,15 @@ timerMod.o: timerMod.f90
 	@echo "Building timer module"
 	$(FC) -c $(FFLAGS) timerMod.f90
 
+cke_mod.o: cke_mod.F90
+	@echo "Building cke module"
+	$(FC) -c $(FFLAGS) cke_mod.F90
+
+.cpp.o:
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+cke.o: cke.hpp cke_impl.hpp
+cke_impl1.o: cke.hpp cke_impl.hpp
+
 clean:
 	/bin/rm -f nested *.o *optrpt *.s *.mod *.MOD
-

--- a/nested_loops/Makefile
+++ b/nested_loops/Makefile
@@ -6,12 +6,10 @@ LDFLAGS =
 # * the EKAT installation root dir
 # * CKE_PACK_SIZE
 EKAT = # no default
-CKE_PACK_SIZE = 4 # CPU default; want 1 on GPU for max performance, but 4 will work
 include make.inc
-CKE_FLAGS = -DUSE_CKE -DCKE_PACK_SIZE=${CKE_PACK_SIZE} \
-	-I${EKAT}/include -I${EKAT}/include/kokkos
+CKE_FLAGS = -DUSE_CKE -I${EKAT}/include -I${EKAT}/include/kokkos
 CKE_LIBS = -lstdc++ -L${EKAT}/lib -L${EKAT}/lib64 -lekat -lkokkoscore -ldl
-CKE_OBJECTS = cke_mod.o cke.o cke_impl1.o
+CKE_OBJECTS = cke_mod.o cke.o cke_impl1.o cke_impl2.o
 
 dummy:
 	@echo "ERROR: Unknown target"
@@ -76,7 +74,7 @@ gnu-cpu-cke:
 	"FC=mpif90" \
 	"CXX=mpicxx" \
 	"FFLAGS=-g -O3 -m64 -fopenmp -Wall -pedantic -DUSE_CKE" \
-	"CXXFLAGS=-std=c++14 -g -O3 -m64 -fopenmp -Wall -pedantic ${CKE_FLAGS}" \
+	"CXXFLAGS=-std=c++14 -g -O3 -m64 -fopenmp -Wall -pedantic ${CKE_FLAGS} -DCKE_PACK_SIZE=4" \
 	"LDFLAGS=-O3 -m64 -fopenmp ${CKE_LIBS}"
 
 gnu-weaver-cke:
@@ -85,7 +83,7 @@ gnu-weaver-cke:
 	"CXX=mpicxx" \
 	"FFLAGS=-g -O3 -m64 -fopenmp -Wall -pedantic -DUSE_CKE" \
 	"CXXFLAGS=-std=c++14 -g -O3 -m64 -fopenmp -Wall -pedantic \
-		-arch=sm_70 --expt-extended-lambda ${CKE_FLAGS}" \
+		-arch=sm_70 --expt-extended-lambda ${CKE_FLAGS} -DCKE_PACK_SIZE=1" \
 	"LDFLAGS=-O3 -m64 -fopenmp ${CKE_LIBS} -lcudadevrt -lcudart_static -lrt"
 
 gnu-summit-cke:
@@ -94,7 +92,7 @@ gnu-summit-cke:
 	"CXX=mpicxx" \
 	"FFLAGS=-g -O3 -m64 -fopenmp -Wall -pedantic -DUSE_CKE -DNO_MPI" \
 	"CXXFLAGS=-std=c++14 -g -O3 -m64 -fopenmp -Wall -pedantic \
-		-arch=sm_70 --expt-extended-lambda ${CKE_FLAGS}" \
+		-arch=sm_70 --expt-extended-lambda ${CKE_FLAGS} -DCKE_PACK_SIZE=1" \
 	"LDFLAGS=-O3 -m64 -fopenmp ${CKE_LIBS} -L${CUDAPATH}/lib64 -lcuda -lcudart"
 
 gnu-compy-cke:
@@ -102,7 +100,7 @@ gnu-compy-cke:
 	"FC=mpiifort" \
 	"CXX=mpiicpc" \
 	"FFLAGS=-g -O3 -m64 -fopenmp -xcore-avx512 -DUSE_CKE -DNO_MPI" \
-	"CXXFLAGS=-std=c++14 -g -O3 -m64 -fopenmp -xcore-avx512 ${CKE_FLAGS}" \
+	"CXXFLAGS=-std=c++14 -g -O3 -m64 -fopenmp -xcore-avx512 ${CKE_FLAGS} -DCKE_PACK_SIZE=8" \
 	"LDFLAGS=-O3 -m64 -fopenmp ${CKE_LIBS}"
 
 nested: nested.o timerMod.o
@@ -130,6 +128,7 @@ cke_mod.o: cke_mod.F90
 
 cke.o: cke.hpp cke_impl.hpp
 cke_impl1.o: cke.hpp cke_impl.hpp
+cke_impl2.o: cke.hpp cke_impl.hpp
 
 clean:
 	/bin/rm -f nested *.o *optrpt *.s *.mod *.MOD

--- a/nested_loops/Makefile
+++ b/nested_loops/Makefile
@@ -4,9 +4,8 @@ LDFLAGS =
 
 # if using C++/Kokkos, set
 # * the EKAT installation root dir
-# * CKE_PACK_SIZE
 EKAT = # no default
-include make.inc
+-include make.inc
 CKE_FLAGS = -DUSE_CKE -I${EKAT}/include -I${EKAT}/include/kokkos
 CKE_LIBS = -lstdc++ -L${EKAT}/lib -L${EKAT}/lib64 -lekat -lkokkoscore -ldl
 CKE_OBJECTS = cke_mod.o cke.o cke_impl1.o cke_impl2.o

--- a/nested_loops/README_cke.txt
+++ b/nested_loops/README_cke.txt
@@ -66,7 +66,6 @@ GNU for Weaver V100:
 2. make.inc:
 
     EKAT = # path to EKAT install directory
-    CKE_PACK_SIZE = 1
 
 Then
 
@@ -100,7 +99,6 @@ module load gcc/9.1.0 cuda/11.0.3 netcdf-fortran/4.4.5 spectrum-mpi/10.4.0.3-202
 2. make.inc:
 
     EKAT = # ...
-    CKE_PACK_SIZE = 1
 
 Then
 
@@ -129,7 +127,6 @@ Compy:
 2. make.inc:
 
     EKAT = # ...
-    CKE_PACK_SIZE = 8 # for AVX512
 
 Then
 

--- a/nested_loops/README_cke.txt
+++ b/nested_loops/README_cke.txt
@@ -1,0 +1,136 @@
+Details for C++/Kokkos/EKAT implementations:
+
+GNU for CPU:
+
+1. Clone, build, and install EKAT as follows:
+
+1a. Clone:
+    git clone git@github.com:E3SM-Project/EKAT.git
+    cd EKAT
+    git submodule update --init --recursive
+
+
+1b. Configure:
+
+    ekatsrc= # path to EKAT repo
+    ekatinstall=ekat-install # or some other path
+    rm -rf CMake*
+    cmake \
+        -D CMAKE_BUILD_TYPE:STRING=RELEASE                \
+        -D CMAKE_CXX_COMPILER:STRING=mpicxx               \
+        -D CMAKE_Fortran_COMPILER:STRING=mpifort          \
+        -D CMAKE_INSTALL_PREFIX:PATH=$ekatinstall         \
+        -D EKAT_ENABLE_TESTS:BOOL=ON                      \
+        -D EKAT_DISABLE_TPL_WARNINGS:BOOL=ON              \
+        -D EKAT_TEST_DOUBLE_PRECISION:BOOL=ON             \
+        -D EKAT_TEST_SINGLE_PRECISION:BOOL=ON             \
+        -D EKAT_TEST_MAX_THREADS:STRING=2                 \
+        $ekatsrc
+
+1c. Build and install:
+
+    make install
+    ctest # verify the build
+
+2. In codesign-kernels/nested_loops, make a make.inc file like this one:
+
+    $ cat make.inc
+    EKAT = # path to EKAT install directory
+
+Then
+
+    make gnu-cpu-cke
+
+GNU for Weaver V100:
+
+1b. EKAT config on Weaver:
+
+    ekatsrc= # path to EKAT repo
+    ekatinstall=ekat-install
+    export OMPI_CXX=${ekatsrc}/extern/kokkos/bin/nvcc_wrapper
+    rm -rf CMakeFiles
+    rm -f  CMakeCache.txt
+    cmake \
+        -C ${ekatsrc}/cmake/machine-files/weaver.cmake  \
+        -D CMAKE_BUILD_TYPE:STRING=RELEASE              \
+        -D CMAKE_CXX_COMPILER:STRING=mpicxx             \
+        -D CMAKE_Fortran_COMPILER:STRING=mpifort        \
+        -D EKAT_DISABLE_TPL_WARNINGS:BOOL=ON            \
+        -D EKAT_DISABLE_TPL_WARNINGS:BOOL=ON            \
+        -D EKAT_ENABLE_TESTS:BOOL=ON                    \
+        -D EKAT_TEST_SINGLE_PRECISION:BOOL=ON           \
+        -D EKAT_TEST_DOUBLE_PRECISION:BOOL=ON           \
+        -D CMAKE_INSTALL_PREFIX:PATH=$ekatinstall       \
+        ${ekatsrc}
+
+2. make.inc:
+
+    EKAT = # path to EKAT install directory
+    CKE_PACK_SIZE = 1
+
+Then
+
+    make gnu-weaver-cke
+
+GNU for Summit V100:
+
+module purge
+module load gcc/9.1.0 cuda/11.0.3 netcdf-fortran/4.4.5 spectrum-mpi/10.4.0.3-20210112 cmake/3.18.4 openblas/0.3.5 nsight-compute/2021.2.1 python/3.7-anaconda3 nsight-systems/2021.3.1.54 netcdf-c/4.8.0
+
+1b. Configure:
+
+    ekatsrc= #...
+    ekatinstall=ekat-install
+    export OMPI_CXX=${ekatsrc}/extern/kokkos/bin/nvcc_wrapper
+    rm -rf CMakeFiles
+    rm -f  CMakeCache.txt
+    cmake \
+        -C ${ekatsrc}/cmake/machine-files/weaver.cmake  \
+        -D CMAKE_BUILD_TYPE:STRING=RELEASE              \
+        -D CMAKE_CXX_COMPILER:STRING=mpicxx             \
+        -D CMAKE_Fortran_COMPILER:STRING=mpifort        \
+        -D EKAT_DISABLE_TPL_WARNINGS:BOOL=ON            \
+        -D EKAT_DISABLE_TPL_WARNINGS:BOOL=ON            \
+        -D EKAT_ENABLE_TESTS:BOOL=ON                    \
+        -D EKAT_TEST_SINGLE_PRECISION:BOOL=ON           \
+        -D EKAT_TEST_DOUBLE_PRECISION:BOOL=ON           \
+        -D CMAKE_INSTALL_PREFIX:PATH=$ekatinstall       \
+        ${ekatsrc}
+
+2. make.inc:
+
+    EKAT = # ...
+    CKE_PACK_SIZE = 1
+
+Then
+
+    make gnu-summit-cke
+
+Compy:
+
+1b. Configure:
+
+    ekatsrc= # ...
+    ekatinstall=install # or some other path
+    rm -rf CMake*
+    cmake \
+        -D Kokkos_ENABLE_OPENMP=On                        \
+        -D CMAKE_BUILD_TYPE:STRING=RELEASE                \
+        -D CMAKE_CXX_COMPILER:STRING=mpiicpc              \
+        -D CMAKE_Fortran_COMPILER:STRING=mpiifort         \
+        -D CMAKE_INSTALL_PREFIX:PATH=$ekatinstall         \
+        -D EKAT_ENABLE_TESTS:BOOL=ON                      \
+        -D EKAT_DISABLE_TPL_WARNINGS:BOOL=ON              \
+        -D EKAT_TEST_DOUBLE_PRECISION:BOOL=ON             \
+        -D EKAT_TEST_SINGLE_PRECISION:BOOL=ON             \
+        -D EKAT_TEST_MAX_THREADS:STRING=2                 \
+        $ekatsrc
+
+2. make.inc:
+
+    EKAT = # ...
+    CKE_PACK_SIZE = 8 # for AVX512
+
+Then
+
+    make gnu-cpu-cke

--- a/nested_loops/cke.cpp
+++ b/nested_loops/cke.cpp
@@ -118,6 +118,7 @@ void cke_get_results (const Int nEdges, const Int nVertLevels,
   for (int i = 0; i < d->nEdges; ++i)
     for (int j = 0; j < nvl; ++j)
       highOrderFlx[nvl*i+j] = h(i,j);
+  Kokkos::deep_copy(d->highOrderFlx, 0);
 }
 
 void cke_cleanup () { cke::g_data = nullptr; }

--- a/nested_loops/cke.cpp
+++ b/nested_loops/cke.cpp
@@ -1,0 +1,123 @@
+#include "cke.hpp"
+#include "cke_impl.hpp"
+
+static bool in_charge_of_kokkos = false;
+
+void kokkos_init () {
+  in_charge_of_kokkos = ! Kokkos::is_initialized();
+  ekat::initialize_ekat_session(false);
+}
+
+void kokkos_finalize () {
+  if (in_charge_of_kokkos && Kokkos::is_initialized())
+    Kokkos::finalize();
+}
+
+namespace cke {
+
+// Initialize a View<const Pack<Real,packn>**> from raw(1:d1,1:d2), where dim 2
+// has the fast index.
+template <typename Scalar, typename V> static void
+initvpk (const Scalar* raw, const int d1, const int d2, const std::string& name, V& v,
+         typename std::enable_if<V::value_type::packtag>::type* = 0) {
+  // Get the number of packs that cover the scalar length.
+  const int d2pk = ekat::PackInfo<V::value_type::n>::num_packs(d2);
+  // Allocate the view as writeable.
+  const auto vnc = typename V::non_const_type(name, d1, d2pk);
+  // For convenience, take a scalar view of the original Pack<Scalar> view.
+  const auto svnc = scalarize(vnc);
+  // Copy the F90 data to a host mirror of the scalar view.
+  const auto h = Kokkos::create_mirror_view(svnc);
+  for (int i = 0; i < d1; ++i)
+    for (int j = 0; j < d2; ++j)
+      h(i,j) = raw[d2*i+j];
+  // Copy the data to device.
+  Kokkos::deep_copy(svnc, h);
+  // Set the possibly read-only view with this data.
+  v = vnc;
+}
+
+// Simpler forms of the above: scalar 1D and 2D views.
+
+template <typename Scalar, typename V> static
+void initv (const Scalar* raw, const int d1, const std::string& name, V& v,
+            const Scalar delta = 0) {
+  const auto vnc = typename V::non_const_type(name, d1);
+  const auto h = Kokkos::create_mirror_view(vnc);
+  for (int i = 0; i < d1; ++i) h(i) = raw[i] + delta;
+  Kokkos::deep_copy(vnc, h);
+  v = vnc;
+}
+
+template <typename Scalar, typename V> static
+void initv (const Scalar* raw, const int d1, const int d2, const std::string& name,
+            V& v, const Scalar delta = 0) {
+  const auto vnc = typename V::non_const_type(name, d1, d2);
+  const auto h = Kokkos::create_mirror_view(vnc);
+  for (int i = 0; i < d1; ++i)
+    for (int j = 0; j < d2; ++j)
+      h(i,j) = raw[d2*i+j] + delta;
+  Kokkos::deep_copy(vnc, h);
+  v = vnc;
+}
+
+void Data::init (
+  const Int nIters_, const Int nEdges_, const Int nCells_, const Int nVertLevels_,
+  const Int nAdv_, const Int* nAdvCellsForEdge_, const Int* minLevelCell_,
+  const Int* maxLevelCell_, const Int* advCellsForEdge_, const Real* tracerCur_,
+  const Real* normalThicknessFlux_, const Real* advMaskHighOrder_, const Real* cellMask_,
+  const Real* advCoefs_, const Real* advCoefs3rd_, const Real coef3rdOrder_)
+{
+  nIters = nIters_; nEdges = nEdges_; nCells = nCells_; nVertLevels = nVertLevels_;
+  nAdv = nAdv_; coef3rdOrder = coef3rdOrder_;
+  nvlpk = ekat::PackInfo<Data::packn>::num_packs(nVertLevels);
+
+  initv(nAdvCellsForEdge_, nEdges, "nAdvCellsForEdge", nAdvCellsForEdge);
+  initv(minLevelCell_, nCells, "minLevelCell", minLevelCell, -1);
+  initv(maxLevelCell_, nCells, "maxLevelCell", maxLevelCell, -1);
+  initv(advCellsForEdge_, nEdges, nAdv, "advCellsForEdge", advCellsForEdge, -1);
+  initv(advCoefs_, nEdges, nAdv, "advCoefs", advCoefs);
+  initv(advCoefs3rd_, nEdges, nAdv, "advCoefs3rd", advCoefs3rd);
+  initvpk(tracerCur_, nCells, nVertLevels, "tracerCur", tracerCur);
+  initvpk(cellMask_, nCells, nVertLevels, "cellMask", cellMask);
+  initvpk(normalThicknessFlux_, nEdges, nVertLevels, "normalThicknessFlux", normalThicknessFlux);
+  initvpk(advMaskHighOrder_, nEdges, nVertLevels, "advMaskHighOrder", advMaskHighOrder);
+
+  const int npack = ekat::PackInfo<packn>::num_packs(nVertLevels);
+  highOrderFlx = Apr2("highOrderFlx", nEdges, npack);
+}
+
+static Data::Ptr g_data;
+
+Data::Ptr get_Data_singleton () { return g_data; }
+
+} // namespace cke
+
+void cke_init (
+  const Int nIters, const Int nEdges, const Int nCells, const Int nVertLevels,
+  const Int nAdv, const Int* nAdvCellsForEdge, const Int* minLevelCell,
+  const Int* maxLevelCell, const Int* advCellsForEdge, const Real* tracerCur,
+  const Real* normalThicknessFlux, const Real* advMaskHighOrder, const Real* cellMask,
+  const Real* advCoefs, const Real* advCoefs3rd, const Real coef3rdOrder)
+{
+  cke::g_data = std::make_shared<cke::Data>();
+  cke::g_data->init(nIters, nEdges, nCells, nVertLevels, nAdv,
+                    nAdvCellsForEdge, minLevelCell, maxLevelCell, advCellsForEdge,
+                    tracerCur, normalThicknessFlux, advMaskHighOrder, cellMask,
+                    advCoefs, advCoefs3rd, coef3rdOrder);
+}
+
+void cke_get_results (const Int nEdges, const Int nVertLevels,
+                      Real* highOrderFlx) {
+  const auto d = cke::g_data;
+  assert(d);
+  const auto shof = scalarize(d->highOrderFlx);
+  const auto h = Kokkos::create_mirror_view(shof);
+  Kokkos::deep_copy(h, shof);
+  const auto nvl = d->nVertLevels;
+  for (int i = 0; i < d->nEdges; ++i)
+    for (int j = 0; j < nvl; ++j)
+      highOrderFlx[nvl*i+j] = h(i,j);
+}
+
+void cke_cleanup () { cke::g_data = nullptr; }

--- a/nested_loops/cke.hpp
+++ b/nested_loops/cke.hpp
@@ -18,6 +18,7 @@ extern "C" {
   void cke_cleanup();
 
   void cke_impl1_run();
+  void cke_impl2_run();
 }
 
 #endif

--- a/nested_loops/cke.hpp
+++ b/nested_loops/cke.hpp
@@ -1,0 +1,23 @@
+#ifndef INCLUDE_CKE_HPP
+#define INCLUDE_CKE_HPP
+
+typedef int Int;
+typedef double Real;
+
+extern "C" {
+  void kokkos_init();
+  void kokkos_finalize();
+
+  void cke_init(
+    const Int nIters, const Int nEdges, const Int nCells, const Int nVertLevels,
+    const Int nAdv, const Int* nAdvCellsForEdge, const Int* minLevelCell,
+    const Int* maxLevelCell, const Int* advCellsForEdge, const Real* tracerCur,
+    const Real* normalThicknessFlux, const Real* advMaskHighOrder, const Real* cellMask,
+    const Real* advCoefs, const Real* advCoefs3rd, const Real coef3rdOrder);
+  void cke_get_results(const Int nEdges, const Int nVertLevels, Real* highOrderFlx);
+  void cke_cleanup();
+
+  void cke_impl1_run();
+}
+
+#endif

--- a/nested_loops/cke_impl.hpp
+++ b/nested_loops/cke_impl.hpp
@@ -1,0 +1,97 @@
+/* General setup, data init, and cleanup for any C++/Kokkos implementation.
+ */
+
+#ifndef INCLUDE_CKE_IMPL_HPP
+#define INCLUDE_CKE_IMPL_HPP
+
+#include <memory>
+
+#include "Kokkos_Core.hpp"
+
+#include "ekat/ekat_session.hpp"
+#include "ekat/ekat_pack.hpp"
+#include "ekat/ekat_pack_utils.hpp"
+#include "ekat/ekat_pack_kokkos.hpp"
+
+namespace cke {
+
+struct Data {
+  typedef std::shared_ptr<Data> Ptr; // convenience: Data::Ptr
+
+  enum : int { packn = CKE_PACK_SIZE }; // pack size
+  typedef ekat::Pack<Real,packn> Pr; // shorthand for a pack of reals
+
+  typedef Kokkos::DefaultExecutionSpace ExeSpace;
+  typedef Kokkos::LayoutRight Layout; // data layout; can switch to experiment
+
+  template <typename Data>
+  using View = Kokkos::View<Data,Layout,ExeSpace,Kokkos::MemoryTraits<Kokkos::Restrict>>;
+
+  // Some handy view aliases.
+  typedef View<Int*> Ai1;
+  typedef View<const Int*> Aci1;
+  typedef View<Int**> Ai2;
+  typedef View<const Int**> Aci2;
+
+  typedef View<Real*> Ar1;
+  typedef View<const Real*> Acr1;
+  typedef View<Real**> Ar2;
+  typedef View<const Real**> Acr2;
+
+  typedef View<Pr*> Apr1;
+  typedef View<const Pr*> Acpr1;
+  typedef View<Pr**> Apr2;
+  typedef View<const Pr**> Acpr2;
+
+  // Read-only data from F90.
+  Int nIters, nEdges, nCells, nVertLevels, nAdv, nvlpk;
+  Real coef3rdOrder;
+  Aci1 nAdvCellsForEdge, minLevelCell, maxLevelCell;
+  Aci2 advCellsForEdge;
+  Acr2 advCoefs, advCoefs3rd;
+  Acpr2 tracerCur, cellMask, normalThicknessFlux, advMaskHighOrder;
+
+  // Output.
+  Apr2 highOrderFlx;
+
+  void init(
+    const Int nIters, const Int nEdges, const Int nCells, const Int nVertLevels,
+    const Int nAdv, const Int* nAdvCellsForEdge, const Int* minLevelCell,
+    const Int* maxLevelCell, const Int* advCellsForEdge, const Real* tracerCur,
+    const Real* normalThicknessFlux, const Real* advMaskHighOrder, const Real* cellMask,
+    const Real* advCoefs, const Real* advCoefs3rd, const Real coef3rdOrder);  
+
+
+  Kokkos::RangePolicy<ExeSpace> get_rpolicy_iEdge () const {
+    return Kokkos::RangePolicy<Data::ExeSpace>(0, nEdges);
+  }
+  Kokkos::RangePolicy<ExeSpace> get_rpolicy_iEdge_kPack () const {
+    return Kokkos::RangePolicy<Data::ExeSpace>(0, nEdges*nvlpk);
+  }
+};
+
+Data::Ptr get_Data_singleton();
+
+// Functor defines void operator()(int,int). Cuda doesn't support std::function,
+// so Functor must be a struct.
+template <typename Functor, typename ExeSpace = Kokkos::DefaultExecutionSpace>
+void parfor_iEdge_kPack (const Data& d, const Functor& f) {
+  const auto nvlpk = d.nvlpk;
+  if (ekat::OnGpu<ExeSpace>::value) {
+    const auto g = KOKKOS_LAMBDA (const int idx) {
+      const int iEdge = idx / nvlpk, k = idx % nvlpk;
+      f(iEdge, k);
+    };
+    Kokkos::parallel_for(d.get_rpolicy_iEdge_kPack(), g);
+  } else {
+    const auto g = KOKKOS_LAMBDA (const int iEdge) {
+      for (int k = 0; k < nvlpk; ++k)
+        f(iEdge, k);
+    };
+    Kokkos::parallel_for(d.get_rpolicy_iEdge(), g);
+  }
+}
+
+} // namespace cke
+
+#endif

--- a/nested_loops/cke_impl1.cpp
+++ b/nested_loops/cke_impl1.cpp
@@ -1,0 +1,43 @@
+#include "cke.hpp"
+#include "cke_impl.hpp"
+
+//sec C++/Kokkos/EKAT demo implementation 1.
+
+namespace cke {
+
+struct NestedLoopKernel {
+  struct Data d;
+  NestedLoopKernel (const Data& d_) : d(d_) {}
+  KOKKOS_FORCEINLINE_FUNCTION void operator() (const Int iEdge, const Int k) const {
+    const auto coef2 = d.normalThicknessFlux(iEdge,k)*d.advMaskHighOrder(iEdge,k);
+    Data::Pr csgn; {
+      const auto ntf = d.normalThicknessFlux(iEdge,k);
+      vector_simd for (int s = 0; s < Data::packn; ++s)
+        csgn[s] = ntf[s] < 0 ? -1 : 1;
+    }
+    Data::Pr edgeFlx(0);
+    const auto iend = d.nAdvCellsForEdge(iEdge);
+    for (int i = 0; i < iend; ++i) {
+      const auto coef1 = d.advCoefs(iEdge,i);
+      const auto coef3 = d.advCoefs3rd(iEdge,i)*d.coef3rdOrder;
+      const auto iCell = d.advCellsForEdge(iEdge,i);
+      edgeFlx += d.tracerCur(iCell,k)*d.cellMask(iCell,k)*coef2*(coef1 + coef3*csgn);
+    }
+    d.highOrderFlx(iEdge,k) = edgeFlx;
+  }
+};
+
+void run (const Data& d) {
+  NestedLoopKernel nlk(d);
+  parfor_iEdge_kPack(d, nlk);
+  Kokkos::fence();
+}
+
+} // namespace cke
+
+void cke_impl1_run () {
+  const auto d = cke::get_Data_singleton();
+  assert(d);
+  for (int iter = 0; iter < d->nIters; ++iter)
+    cke::run(*d);
+}

--- a/nested_loops/cke_impl1.cpp
+++ b/nested_loops/cke_impl1.cpp
@@ -1,9 +1,11 @@
 #include "cke.hpp"
 #include "cke_impl.hpp"
 
-//sec C++/Kokkos/EKAT demo implementation 1.
+using namespace cke;
 
-namespace cke {
+// C++/Kokkos/EKAT demo implementation 1.
+
+namespace {
 
 struct NestedLoopKernel {
   struct Data d;
@@ -33,11 +35,11 @@ void run (const Data& d) {
   Kokkos::fence();
 }
 
-} // namespace cke
+} // namespace
 
 void cke_impl1_run () {
   const auto d = cke::get_Data_singleton();
   assert(d);
   for (int iter = 0; iter < d->nIters; ++iter)
-    cke::run(*d);
+    run(*d);
 }

--- a/nested_loops/cke_impl2.cpp
+++ b/nested_loops/cke_impl2.cpp
@@ -1,0 +1,78 @@
+#include "cke.hpp"
+#include "cke_impl.hpp"
+
+// C++/Kokkos/EKAT demo implementation 2.
+
+using namespace cke;
+
+namespace {
+
+struct NestedLoopKernel {
+  struct Data d;
+  NestedLoopKernel (const Data& d_) : d(d_) {}
+
+  KOKKOS_INLINE_FUNCTION size_t get_col_size () const {
+    return d.nvlpk*sizeof(Data::Pr);
+  }
+
+  size_t team_shmem_size (const int team_size) const {
+    return 3*get_col_size();
+  }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  void operator() (const Data::TeamMember& team) const {
+    const int iEdge = team.league_rank();
+    const auto col_sz = get_col_size();
+    auto* const wgtTmp = static_cast<Data::Pr*>(team.team_shmem().get_shmem(3*col_sz));
+    auto* const sgnTmp = wgtTmp + d.nvlpk;
+    auto* const flxTmp = sgnTmp + d.nvlpk;
+    const auto f1 = [&] (const int k) {
+      wgtTmp[k] = d.normalThicknessFlux(iEdge,k)*d.advMaskHighOrder(iEdge,k);
+      Data::Pr csgn; {
+        const auto ntf = d.normalThicknessFlux(iEdge,k);
+        vector_simd for (int s = 0; s < Data::packn; ++s)
+          csgn[s] = ntf[s] < 0 ? -1 : 1;
+      }
+      sgnTmp[k] = csgn;
+      flxTmp[k] = 0;
+    };
+    // Technically need a vector-range loop or single inside the team thread
+    // loop, but not needed if the vector extent is guaranteed to be 1.
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, d.nvlpk), f1);
+    team.team_barrier();
+    const auto iend = d.nAdvCellsForEdge(iEdge);
+    for (int i = 0; i < iend; ++i) {
+      const auto coef1 = d.advCoefs(iEdge,i);
+      const auto coef3 = d.advCoefs3rd(iEdge,i)*d.coef3rdOrder;
+      const auto iCell = d.advCellsForEdge(iEdge,i);
+      const int kbeg = d.minLevelCell(iCell)/Data::packn;
+      const int kend = d.maxLevelCell(iCell)/Data::packn;
+      const auto f2 = [&] (const int kos) {
+        const int k = kbeg + kos;
+        flxTmp[k] += (d.tracerCur(iCell,k)*d.cellMask(iCell,k)*
+                      wgtTmp[k]*(coef1 + coef3*sgnTmp[k]));
+      };
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, kend-kbeg+1), f2);
+    }
+    team.team_barrier();
+    const auto f3 = [&] (const int k) {
+      d.highOrderFlx(iEdge,k) = flxTmp[k];
+    };
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, d.nvlpk), f3);
+  }
+};
+
+void run (const Data& d) {
+  NestedLoopKernel nlk(d);
+  Kokkos::parallel_for(d.get_tpolicy_iEdge(), nlk);
+  Kokkos::fence();
+}
+
+} // namespace
+
+void cke_impl2_run () {
+  const auto d = cke::get_Data_singleton();
+  assert(d);
+  for (int iter = 0; iter < d->nIters; ++iter)
+    run(*d);
+}

--- a/nested_loops/cke_mod.F90
+++ b/nested_loops/cke_mod.F90
@@ -31,6 +31,8 @@ module cke_mod
 
      subroutine cke_impl1_run() bind(c)
      end subroutine cke_impl1_run
+     subroutine cke_impl2_run() bind(c)
+     end subroutine cke_impl2_run
 
      subroutine cke_get_results(nEdges, nVertLevels, highOrderFlx) bind(c)
        use iso_c_binding, only: c_int, c_double

--- a/nested_loops/cke_mod.F90
+++ b/nested_loops/cke_mod.F90
@@ -1,0 +1,48 @@
+module cke_mod
+  implicit none
+
+  interface
+
+     subroutine kokkos_init() bind(c)
+     end subroutine kokkos_init
+
+     subroutine kokkos_finalize() bind(c)
+     end subroutine kokkos_finalize
+
+     subroutine cke_init(nIters, nEdges, nCells, nVertLevels, nAdv, &
+          nAdvCellsForEdge, minLevelCell, maxLevelCell, advCellsForEdge, &
+          tracerCur, normalThicknessFlux, advMaskHighOrder, cellMask, &
+          advCoefs, advCoefs3rd, coef3rdOrder) bind(c)
+       use iso_c_binding, only: c_int, c_double
+       integer(c_int), value, intent(in) :: &
+            nIters, nEdges, nCells, nVertLevels, nAdv
+       real(c_double), value, intent(in) :: &
+            coef3rdOrder
+       integer(c_int), intent(in) :: &
+            nAdvCellsForEdge(nEdges), minLevelCell(nCells), maxLevelCell(nCells), &
+            advCellsForEdge(nAdv,nEdges)
+       real(c_double), dimension(nVertLevels,nCells), intent(in) :: &
+            tracerCur, cellMask
+       real(c_double), dimension(nVertLevels,nEdges), intent(in) :: &
+            normalThicknessFlux, advMaskHighOrder
+       real(c_double), dimension(nAdv,nEdges), intent(in) :: &
+            advCoefs, advCoefs3rd
+     end subroutine cke_init
+
+     subroutine cke_impl1_run() bind(c)
+     end subroutine cke_impl1_run
+
+     subroutine cke_get_results(nEdges, nVertLevels, highOrderFlx) bind(c)
+       use iso_c_binding, only: c_int, c_double
+       integer(c_int), value, intent(in) :: &
+            nEdges, nVertLevels
+       real(c_double), dimension(nVertLevels,nEdges), intent(out) :: &
+            highOrderFlx
+     end subroutine cke_get_results
+
+     subroutine cke_cleanup() bind(c)
+     end subroutine cke_cleanup
+
+  end interface
+
+end module cke_mod

--- a/nested_loops/nested.F90
+++ b/nested_loops/nested.F90
@@ -461,12 +461,12 @@ program nested
         advCoefs, advCoefs3rd, coef3rdOrder)
    call timerStop(timerData)
 
-   do i = 1,1
+   do i = 1,2
       timer_cke = timerCreate('C++/Kokkos ' // char(48+i))
       call timerStart(timer_cke)
       select case(i)
-      case (1)
-         call cke_impl1_run()
+      case (1); call cke_impl1_run()
+      case (2); call cke_impl2_run()
       ! other impls go here
       end select
       call timerStop(timer_cke)
@@ -474,7 +474,6 @@ program nested
 
       call timerStart(timerData)
       call cke_get_results(nEdges, nVertLevels, highOrderFlx)
-      call cke_cleanup()
       call timerStop(timerData)
 
       iCell = 0;
@@ -493,6 +492,7 @@ program nested
       end do
    end do
 
+   call cke_cleanup()
    call kokkos_finalize()
 #endif
 


### PR DESCRIPTION
This PR brings in:
* F90 <-> C++ bridges;
* a reference RangePolicy implementation;
* a reference TeamPolicy implementation.

Both implementations use packs. README_cke.txt contains instructions for running on Compy, Summit, and a generic Linux workstation.