### PR TITLE
F90 loop rebased against updated SHA1s

### DIFF
--- a/nested_loops/Makefile
+++ b/nested_loops/Makefile
@@ -72,7 +72,7 @@ gnu-cpu-cke:
 	make nestedcke \
 	"FC=mpif90" \
 	"CXX=mpicxx" \
-	"FFLAGS=-g -O3 -m64 -fopenmp -Wall -pedantic -DUSE_CKE" \
+	"FFLAGS=-g -O3 -m64 -fopenmp -Wall -pedantic -DUSE_CKE -DF90_PACK_SIZE=4" \
 	"CXXFLAGS=-std=c++14 -g -O3 -m64 -fopenmp -Wall -pedantic ${CKE_FLAGS} -DCKE_PACK_SIZE=4" \
 	"LDFLAGS=-O3 -m64 -fopenmp ${CKE_LIBS}"
 
@@ -80,7 +80,7 @@ gnu-weaver-cke:
 	make nestedcke \
 	"FC=mpif90" \
 	"CXX=mpicxx" \
-	"FFLAGS=-g -O3 -m64 -fopenmp -Wall -pedantic -DUSE_CKE" \
+	"FFLAGS=-g -O3 -m64 -fopenmp -Wall -pedantic -DUSE_CKE -DF90_PACK_SIZE=8" \
 	"CXXFLAGS=-std=c++14 -g -O3 -m64 -fopenmp -Wall -pedantic \
 		-arch=sm_70 --expt-extended-lambda ${CKE_FLAGS} -DCKE_PACK_SIZE=1" \
 	"LDFLAGS=-O3 -m64 -fopenmp ${CKE_LIBS} -lcudadevrt -lcudart_static -lrt"
@@ -89,7 +89,7 @@ gnu-summit-cke:
 	make nestedcke \
 	"FC=mpif90" \
 	"CXX=mpicxx" \
-	"FFLAGS=-g -O3 -m64 -fopenmp -Wall -pedantic -DUSE_CKE -DNO_MPI" \
+	"FFLAGS=-g -O3 -m64 -fopenmp -Wall -pedantic -DUSE_CKE -DF90_PACK_SIZE=8 -DNO_MPI" \
 	"CXXFLAGS=-std=c++14 -g -O3 -m64 -fopenmp -Wall -pedantic \
 		-arch=sm_70 --expt-extended-lambda ${CKE_FLAGS} -DCKE_PACK_SIZE=1" \
 	"LDFLAGS=-O3 -m64 -fopenmp ${CKE_LIBS} -L${CUDAPATH}/lib64 -lcuda -lcudart"
@@ -98,7 +98,7 @@ gnu-compy-cke:
 	make nestedcke \
 	"FC=mpiifort" \
 	"CXX=mpiicpc" \
-	"FFLAGS=-g -O3 -m64 -fopenmp -xcore-avx512 -DUSE_CKE -DNO_MPI" \
+	"FFLAGS=-g -O3 -m64 -fopenmp -xcore-avx512 -DUSE_CKE -DNO_MPI -DF90_PACK_SIZE=16" \
 	"CXXFLAGS=-std=c++14 -g -O3 -m64 -fopenmp -xcore-avx512 ${CKE_FLAGS} -DCKE_PACK_SIZE=8" \
 	"LDFLAGS=-O3 -m64 -fopenmp ${CKE_LIBS}"
 

--- a/nested_loops/Makefile
+++ b/nested_loops/Makefile
@@ -94,7 +94,7 @@ gnu-summit-cke:
 		-arch=sm_70 --expt-extended-lambda ${CKE_FLAGS} -DCKE_PACK_SIZE=1" \
 	"LDFLAGS=-O3 -m64 -fopenmp ${CKE_LIBS} -L${CUDAPATH}/lib64 -lcuda -lcudart"
 
-gnu-compy-cke:
+intel-compy-cke:
 	make nestedcke \
 	"FC=mpiifort" \
 	"CXX=mpiicpc" \

--- a/nested_loops/README_cke.txt
+++ b/nested_loops/README_cke.txt
@@ -130,4 +130,4 @@ Compy:
 
 Then
 
-    make gnu-cpu-cke
+    make intel-cpu-cke

--- a/nested_loops/cke.cpp
+++ b/nested_loops/cke.cpp
@@ -90,7 +90,7 @@ void initv (const Scalar* raw, const int d1, const int d2, const std::string& na
 void Data::init (
   const Int nIters_, const Int nEdges_, const Int nCells_, const Int nVertLevels_,
   const Int nvldim_, const Int nAdv_, const Int* nAdvCellsForEdge_, const Int* minLevelCell_,
-  const Int* maxLevelCell_, const Int* advCellsForEdge_, const Real* tracerCur_,
+  const Int* maxLevelCell_, const Int* advCellsForEdge_, Real* tracerCur_,
   const Real* normalThicknessFlux_, const Real* advMaskHighOrder_, const Real* cellMask_,
   const Real* advCoefs_, const Real* advCoefs3rd_, const Real coef3rdOrder_,
   Real* highOrderFlx_)
@@ -128,7 +128,7 @@ Data::Ptr get_Data_singleton () { return g_data; }
 void cke_init (
   const Int nIters, const Int nEdges, const Int nCells, const Int nVertLevels,
   const Int nvldim, const Int nAdv, const Int* nAdvCellsForEdge, const Int* minLevelCell,
-  const Int* maxLevelCell, const Int* advCellsForEdge, const Real* tracerCur,
+  const Int* maxLevelCell, const Int* advCellsForEdge, Real* tracerCur,
   const Real* normalThicknessFlux, const Real* advMaskHighOrder, const Real* cellMask,
   const Real* advCoefs, const Real* advCoefs3rd, const Real coef3rdOrder,
   Real* highOrderFlx)

--- a/nested_loops/cke.hpp
+++ b/nested_loops/cke.hpp
@@ -11,7 +11,7 @@ extern "C" {
   void cke_init(
     const Int nIters, const Int nEdges, const Int nCells, const Int nVertLevels,
     const Int nvldim, const Int nAdv, const Int* nAdvCellsForEdge, const Int* minLevelCell,
-    const Int* maxLevelCell, const Int* advCellsForEdge, const Real* tracerCur,
+    const Int* maxLevelCell, const Int* advCellsForEdge, Real* tracerCur,
     const Real* normalThicknessFlux, const Real* advMaskHighOrder, const Real* cellMask,
     const Real* advCoefs, const Real* advCoefs3rd, const Real coef3rdOrder,
     Real* highOrderFlx);

--- a/nested_loops/cke.hpp
+++ b/nested_loops/cke.hpp
@@ -13,7 +13,8 @@ extern "C" {
     const Int nvldim, const Int nAdv, const Int* nAdvCellsForEdge, const Int* minLevelCell,
     const Int* maxLevelCell, const Int* advCellsForEdge, const Real* tracerCur,
     const Real* normalThicknessFlux, const Real* advMaskHighOrder, const Real* cellMask,
-    const Real* advCoefs, const Real* advCoefs3rd, const Real coef3rdOrder);
+    const Real* advCoefs, const Real* advCoefs3rd, const Real coef3rdOrder,
+    Real* highOrderFlx);
   void cke_get_results(const Int nEdges, const Int nVertLevels, Real* highOrderFlx);
   void cke_cleanup();
 

--- a/nested_loops/cke.hpp
+++ b/nested_loops/cke.hpp
@@ -10,7 +10,7 @@ extern "C" {
 
   void cke_init(
     const Int nIters, const Int nEdges, const Int nCells, const Int nVertLevels,
-    const Int nAdv, const Int* nAdvCellsForEdge, const Int* minLevelCell,
+    const Int nvldim, const Int nAdv, const Int* nAdvCellsForEdge, const Int* minLevelCell,
     const Int* maxLevelCell, const Int* advCellsForEdge, const Real* tracerCur,
     const Real* normalThicknessFlux, const Real* advMaskHighOrder, const Real* cellMask,
     const Real* advCoefs, const Real* advCoefs3rd, const Real coef3rdOrder);

--- a/nested_loops/cke_impl.hpp
+++ b/nested_loops/cke_impl.hpp
@@ -45,7 +45,7 @@ struct Data {
   typedef View<const Pr**> Acpr2;
 
   // Read-only data from F90.
-  Int nIters, nEdges, nCells, nVertLevels, nAdv, nvlpk;
+  Int nIters, nEdges, nCells, nVertLevels, nvldim, nAdv, nvlpk;
   Real coef3rdOrder;
   Aci1 nAdvCellsForEdge, minLevelCell, maxLevelCell;
   Aci2 advCellsForEdge;
@@ -57,7 +57,7 @@ struct Data {
 
   void init(
     const Int nIters, const Int nEdges, const Int nCells, const Int nVertLevels,
-    const Int nAdv, const Int* nAdvCellsForEdge, const Int* minLevelCell,
+    const Int nvldim, const Int nAdv, const Int* nAdvCellsForEdge, const Int* minLevelCell,
     const Int* maxLevelCell, const Int* advCellsForEdge, const Real* tracerCur,
     const Real* normalThicknessFlux, const Real* advMaskHighOrder, const Real* cellMask,
     const Real* advCoefs, const Real* advCoefs3rd, const Real coef3rdOrder);  

--- a/nested_loops/cke_impl.hpp
+++ b/nested_loops/cke_impl.hpp
@@ -50,7 +50,8 @@ struct Data {
   Aci1 nAdvCellsForEdge, minLevelCell, maxLevelCell;
   Aci2 advCellsForEdge;
   Acr2 advCoefs, advCoefs3rd;
-  Acpr2 tracerCur, cellMask, normalThicknessFlux, advMaskHighOrder;
+  Apr2 tracerCur;
+  Acpr2 cellMask, normalThicknessFlux, advMaskHighOrder;
 
   // Output.
   Apr2 highOrderFlx;
@@ -58,10 +59,29 @@ struct Data {
   void init(
     const Int nIters, const Int nEdges, const Int nCells, const Int nVertLevels,
     const Int nvldim, const Int nAdv, const Int* nAdvCellsForEdge, const Int* minLevelCell,
-    const Int* maxLevelCell, const Int* advCellsForEdge, const Real* tracerCur,
+    const Int* maxLevelCell, const Int* advCellsForEdge, Real* tracerCur,
     const Real* normalThicknessFlux, const Real* advMaskHighOrder, const Real* cellMask,
     const Real* advCoefs, const Real* advCoefs3rd, const Real coef3rdOrder,
-    Real* highOrderFlx);  
+    Real* highOrderFlx);
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  void get_iEdge_kPack_idxs (const int idx, int& iEdge, int& k) const {
+    iEdge = idx / nvlpk;
+    k = idx % nvlpk;
+  }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  void get_iCell_kPack_idxs (const int idx, int& iCell, int& k) const {
+    iCell = idx / nvlpk;
+    k = idx % nvlpk;
+  }
+
+  Kokkos::RangePolicy<ExeSpace> get_rpolicy_iCell () const {
+    return Kokkos::RangePolicy<Data::ExeSpace>(0, nCells);
+  }
+  Kokkos::RangePolicy<ExeSpace> get_rpolicy_iCell_kPack () const {
+    return Kokkos::RangePolicy<Data::ExeSpace>(0, nCells*nvlpk);
+  }
 
   Kokkos::RangePolicy<ExeSpace> get_rpolicy_iEdge () const {
     return Kokkos::RangePolicy<Data::ExeSpace>(0, nEdges);

--- a/nested_loops/cke_impl.hpp
+++ b/nested_loops/cke_impl.hpp
@@ -60,7 +60,8 @@ struct Data {
     const Int nvldim, const Int nAdv, const Int* nAdvCellsForEdge, const Int* minLevelCell,
     const Int* maxLevelCell, const Int* advCellsForEdge, const Real* tracerCur,
     const Real* normalThicknessFlux, const Real* advMaskHighOrder, const Real* cellMask,
-    const Real* advCoefs, const Real* advCoefs3rd, const Real coef3rdOrder);  
+    const Real* advCoefs, const Real* advCoefs3rd, const Real coef3rdOrder,
+    Real* highOrderFlx);  
 
   Kokkos::RangePolicy<ExeSpace> get_rpolicy_iEdge () const {
     return Kokkos::RangePolicy<Data::ExeSpace>(0, nEdges);

--- a/nested_loops/cke_impl2.cpp
+++ b/nested_loops/cke_impl2.cpp
@@ -1,7 +1,10 @@
 #include "cke.hpp"
 #include "cke_impl.hpp"
 
-// C++/Kokkos/EKAT demo implementation 2.
+// C++/Kokkos/EKAT demo implementation 2. This code demonstrates hierarchical
+// parallelism, including suing shared scratch memory. It isn't very fast
+// because for this particular kernel, hierarchical ||ism is not well motivated.
+// A little bit of work might speed it up a little, though.
 
 using namespace cke;
 

--- a/nested_loops/cke_mod.F90
+++ b/nested_loops/cke_mod.F90
@@ -9,13 +9,13 @@ module cke_mod
      subroutine kokkos_finalize() bind(c)
      end subroutine kokkos_finalize
 
-     subroutine cke_init(nIters, nEdges, nCells, nVertLevels, nAdv, &
+     subroutine cke_init(nIters, nEdges, nCells, nVertLevels, nvldim, nAdv, &
           nAdvCellsForEdge, minLevelCell, maxLevelCell, advCellsForEdge, &
           tracerCur, normalThicknessFlux, advMaskHighOrder, cellMask, &
           advCoefs, advCoefs3rd, coef3rdOrder) bind(c)
        use iso_c_binding, only: c_int, c_double
        integer(c_int), value, intent(in) :: &
-            nIters, nEdges, nCells, nVertLevels, nAdv
+            nIters, nEdges, nCells, nVertLevels, nvldim, nAdv
        real(c_double), value, intent(in) :: &
             coef3rdOrder
        integer(c_int), intent(in) :: &

--- a/nested_loops/cke_mod.F90
+++ b/nested_loops/cke_mod.F90
@@ -12,7 +12,7 @@ module cke_mod
      subroutine cke_init(nIters, nEdges, nCells, nVertLevels, nvldim, nAdv, &
           nAdvCellsForEdge, minLevelCell, maxLevelCell, advCellsForEdge, &
           tracerCur, normalThicknessFlux, advMaskHighOrder, cellMask, &
-          advCoefs, advCoefs3rd, coef3rdOrder) bind(c)
+          advCoefs, advCoefs3rd, coef3rdOrder, highOrderFlx) bind(c)
        use iso_c_binding, only: c_int, c_double
        integer(c_int), value, intent(in) :: &
             nIters, nEdges, nCells, nVertLevels, nvldim, nAdv
@@ -21,12 +21,14 @@ module cke_mod
        integer(c_int), intent(in) :: &
             nAdvCellsForEdge(nEdges), minLevelCell(nCells), maxLevelCell(nCells), &
             advCellsForEdge(nAdv,nEdges)
-       real(c_double), dimension(nVertLevels,nCells), intent(in) :: &
+       real(c_double), dimension(nvldim,nCells), intent(in) :: &
             tracerCur, cellMask
-       real(c_double), dimension(nVertLevels,nEdges), intent(in) :: &
+       real(c_double), dimension(nvldim,nEdges), intent(in) :: &
             normalThicknessFlux, advMaskHighOrder
        real(c_double), dimension(nAdv,nEdges), intent(in) :: &
             advCoefs, advCoefs3rd
+       real(c_double), dimension(nvldim,nEdges), intent(inout) :: &
+            highOrderFlx
      end subroutine cke_init
 
      subroutine cke_impl1_run() bind(c)
@@ -34,11 +36,11 @@ module cke_mod
      subroutine cke_impl2_run() bind(c)
      end subroutine cke_impl2_run
 
-     subroutine cke_get_results(nEdges, nVertLevels, highOrderFlx) bind(c)
+     subroutine cke_get_results(nEdges, nvldim, highOrderFlx) bind(c)
        use iso_c_binding, only: c_int, c_double
        integer(c_int), value, intent(in) :: &
-            nEdges, nVertLevels
-       real(c_double), dimension(nVertLevels,nEdges), intent(out) :: &
+            nEdges, nvldim
+       real(c_double), dimension(nvldim,nEdges), intent(out) :: &
             highOrderFlx
      end subroutine cke_get_results
 

--- a/nested_loops/nested.F90
+++ b/nested_loops/nested.F90
@@ -554,7 +554,7 @@ program nested
    call cke_init(nIters, nEdges, nCells, nVertLevels, nvldim, nAdv, &
         nAdvCellsForEdge, minLevelCell, maxLevelCell, advCellsForEdge, &
         tracerCur, normalThicknessFlux, advMaskHighOrder, cellMask, &
-        advCoefs, advCoefs3rd, coef3rdOrder)
+        advCoefs, advCoefs3rd, coef3rdOrder, highOrderFlx)
    call timerStop(timerData)
 
    do i = 1,2

--- a/nested_loops/nested.F90
+++ b/nested_loops/nested.F90
@@ -473,8 +473,8 @@ program nested
 #endif
 #ifdef USE_OMPOFFLOAD
       !$omp target teams &
-      !$omp    map(to: tracerCur, cellMask) &
-      !$omp    map(from: tracerCur)
+      !$omp    map(to: cellMask) &
+      !$omp    map(tofrom: tracerCur)
       !$omp distribute parallel do collapse(2)
 #endif      
       do iCell = 1, nCells
@@ -500,7 +500,7 @@ program nested
       !$omp            advCoefs, advCoefs3rd, tracerCur) &
       !$omp    map(from: highOrderFlx)
       !$omp distribute parallel do collapse(2) &
-      !$omp    private(iCell, coef1, coef2pk, coef3, edgeFlxPk,csgnpk)
+      !$omp    private(iCell, k0, coef1, coef2pk, coef3, edgeFlxPk, csgnpk)
 #endif
       do iEdge = 1, nEdges
       do k = 0, nvlpk-1

--- a/nested_loops/nested.F90
+++ b/nested_loops/nested.F90
@@ -478,9 +478,8 @@ program nested
       !$omp distribute parallel do collapse(2)
 #endif      
       do iCell = 1, nCells
-         do k = 0, nvlpk-1
-            k0 = packn*k
-            tracerCur(pkslc(k0),iCell) = tracerCur(pkslc(k0),iCell)*cellMask(pkslc(k0),iCell)
+         do k = 1, nVertLevels
+            tracerCur(k,iCell) = tracerCur(k,iCell)*cellMask(k,iCell)
          end do
       end do
 #ifdef USE_OMPOFFLOAD


### PR DESCRIPTION
I noticed PRs #4 and #5 have a large number of conflicts w.r.t. to the main branch. This is because the SHA1s of the commits in PR #3 were rewritten for some reason when the PR was merged to the main branch. This PR cherry-picks the commits from PRs #3 and #4, based on the current main branch. This resolves the conflicts; I'll close those now-redundant PRs in favor of this one.